### PR TITLE
use current stripes-form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change history for ui-tags
 
+## 1.1.0 (IN PROGRESS)
+
+* Update to stripes-form 0.9.0. Refs STRIPES-555.
 
 ## [1.0.2](https://github.com/folio-org/ui-tags/tree/v1.0.2) (2018-09-13)
 [Full Changelog](https://github.com/folio-org/ui-tags/compare/v1.0.2...v1.0.0)

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@folio/stripes-components": "^3.0.10",
     "@folio/stripes-core": "^2.11.0",
-    "@folio/stripes-form": "^0.8.2",
+    "@folio/stripes-form": "^0.9.0",
     "@folio/stripes-smart-components": "^1.6.0",
     "isomorphic-fetch": "^2.2.1",
     "lodash": "^4.17.4",


### PR DESCRIPTION
Because stripes-form has not been released as a v1.0.x package,
this means ^0.8.0 is effectively ~0.8.0, meaning those packages
are locked at 0.8.x, not 0.x.x as intended. stripes-form 0.8.0
pulled in an old version of stripes-components which pulled in
an old version of React which brought darkness upon the land.

Refs [STRIPES-555](https://issues.folio.org/browse/STRIPES-555)