### PR TITLE
make stripes-core a peerDependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-tags
 
+## 1.0.4 (IN PROGRESS)
+
+* stripes-core should be a peerDependency. Refs STRIPES-557.
+
 ## [1.0.3](https://github.com/folio-org/ui-tags/tree/v1.0.3) (2018-09-14)
 [Full Changelog](https://github.com/folio-org/ui-tags/compare/v1.0.2...v1.0.3)
 

--- a/package.json
+++ b/package.json
@@ -49,13 +49,13 @@
   "devDependencies": {
     "@folio/eslint-config-stripes": "^3.1.1",
     "@folio/stripes-cli": "^1.3.1",
+    "@folio/stripes-core": "^2.11.0",
     "react-intl": "^2.4.0",
     "webpack": "^4.10.2",
     "eslint": "^5.5.0"
   },
   "dependencies": {
     "@folio/stripes-components": "^3.0.10",
-    "@folio/stripes-core": "^2.11.0",
     "@folio/stripes-form": "^0.9.0",
     "@folio/stripes-smart-components": "^1.6.0",
     "isomorphic-fetch": "^2.2.1",


### PR DESCRIPTION
stripes-core must be a peerDependency so it is included once per bundle.
Listing it as a regular dependency means it may be nested, rather than
hoisted, which can lead to multiple versions, but separate versions will
have separate instances of context, resulting in context-consumers that
can't see the context offered by the context-providers they are trying
to subscribe too.

Refs [STRIPES-557](https://issues.folio.org/browse/STRIPES-557)