### PR TITLE
Replace stripes.intl with FormattedMessage

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
   },
   "dependencies": {
     "prop-types": "^15.5.10",
+    "react-intl": "^2.7.2",
     "redux-form": "^7.0.3"
   },
   "peerDependencies": {

--- a/settings/TagSettings.js
+++ b/settings/TagSettings.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
 import { Field } from 'redux-form';
 import { Checkbox, Col, Row } from '@folio/stripes/components';
 import { ConfigManager } from '@folio/stripes/smart-components';
@@ -9,7 +10,6 @@ class TagSettings extends React.Component {
     label: PropTypes.string,
     stripes: PropTypes.shape({
       connect: PropTypes.func.isRequired,
-      intl: PropTypes.object.isRequired,
     }).isRequired,
   };
 
@@ -38,7 +38,7 @@ class TagSettings extends React.Component {
               component={Checkbox}
               id="tags_enabled"
               name="tags_enabled"
-              label={this.props.stripes.intl.formatMessage({ id: 'ui-tags.settings.enableTags' })}
+              label={<FormattedMessage id="ui-tags.settings.enableTags" />}
             />
           </Col>
         </Row>

--- a/settings/index.js
+++ b/settings/index.js
@@ -1,22 +1,17 @@
 import React from 'react';
+import { FormattedMessage } from 'react-intl';
 import { Settings } from '@folio/stripes/smart-components';
-import { stripesShape } from '@folio/stripes/core';
 
 import TagSettings from './TagSettings';
 
-class Tags extends React.Component {
-  static propTypes = {
-    stripes: stripesShape.isRequired,
-  }
-
+export default class Tags extends React.Component {
   constructor(props) {
     super(props);
-    const formatMsg = this.props.stripes.intl.formatMessage;
 
     this.pages = [
       {
         route: 'general',
-        label: formatMsg({ id: 'ui-tags.settings.general.label' }),
+        label: <FormattedMessage id="ui-tags.settings.general.label" />,
         component: TagSettings,
       }
     ];
@@ -27,10 +22,8 @@ class Tags extends React.Component {
       <Settings
         {...this.props}
         pages={this.pages}
-        paneTitle={this.props.stripes.intl.formatMessage({ id: 'ui-tags.settings.index.paneTitle' })}
+        paneTitle={<FormattedMessage id="ui-tags.settings.index.paneTitle" />}
       />
     );
   }
 }
-
-export default Tags;


### PR DESCRIPTION
`stripes.intl` is deprecated and will soon be removed from `stripes-core`.

Updates to the preferred `<FormattedMessage>` usage.