### PR TITLE
Fixes bug to correctly show the checked status of the Tags checkbox, …

### DIFF
--- a/settings/TagSettings.js
+++ b/settings/TagSettings.js
@@ -36,6 +36,7 @@ class TagSettings extends React.Component {
           <Col xs={12}>
             <Field
               component={Checkbox}
+              type="checkbox"
               id="tags_enabled"
               name="tags_enabled"
               label={<FormattedMessage id="ui-tags.settings.enableTags" />}


### PR DESCRIPTION
…refs ERM-173

- The `type="checkbox"` prop needs to be passed to the `<Field>` to correctly pass the `checked` prop to the input. The `checked` attribute corresponds to the actual user-applied value. This fixes the issue with the mismatch between the `value` and the `checked` status on the enable tags checkbox.