### PR TITLE
STCOR-148 migrate to actsAs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Update eslint to v6.2.1. Refs UITAG-26
 * Update `@folio/stripes` to `v3.0.0`.
+* Migrate from `stripes.type` to `stripes.actsAs`
 
 ## [1.3.3](https://github.com/folio-org/ui-tags/tree/v1.3.3) (2019-12-04)
 [Full Changelog](https://github.com/folio-org/ui-tags/compare/v1.3.2...v1.3.3)

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "main": "index.js",
   "stripes": {
-    "type": "settings",
+    "actsAs": ["settings"],
     "displayName": "ui-tags.meta.title",
     "route": "/tags",
     "hasSettings": true,


### PR DESCRIPTION
A stripes module can be more than one type, presenting an array in
`actsAs` rather than a single string to `type`.

Refs [STCOR-148](https://issues.folio.org/browse/STCOR-148)