### PR TITLE
Removed invalid 'icons' entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,13 +17,7 @@
     "route": "/tags",
     "hasSettings": true,
     "queryResource": "query",
-    "icons": [
-      {
-        "name": "app",
-        "alt": "Create and manage tags",
-        "title": "tags"
-      }
-    ],
+    "icons": [],
     "okapiInterfaces": {
       "tags": "1.0"
     },


### PR DESCRIPTION
There aren't any icons for this module so we're constantly getting spammed with
```
  Module @folio/tags defines icon "app" but is missing file "icons/app.svg"
  Module @folio/tags defines icon "app" but is missing file "icons/app.png"
```