### PR TITLE
UITAG-29, UITAG-10 provide tag-related permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-tags
 
+## 3.1.0 (IN PROGRESS)
+
+* Provide visible permission sets for managing and view tags. Refs UITAG-29, UITAG-10.
+
 ## [3.0.0](https://github.com/folio-org/ui-tags/tree/v3.0.0) (2020-06-10)
 [Full Changelog](https://github.com/folio-org/ui-tags/compare/v2.0.0...v3.0.0)
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,54 @@
           "settings.enabled"
         ],
         "visible": true
+      },
+      {
+        "permissionName": "ui-tags.all",
+        "subPermissions": [
+          "module.tags.enabled",
+          "ui-tags.view",
+          "ui-tags.create",
+          "ui-tags.edit",
+          "ui-tags.delete"
+        ],
+        "visible": true
+      },
+      {
+        "permissionName": "ui-tags.view",
+        "subPermissions": [
+          "module.tags.enabled",
+          "tags.collection.get"
+        ],
+        "visible": true
+      },
+      {
+        "permissionName": "ui-tags.create",
+        "subPermissions": [
+          "module.tags.enabled",
+          "tags.collection.get",
+          "tags.item.post"
+        ],
+        "visible": false
+      },
+      {
+        "permissionName": "ui-tags.edit",
+        "subPermissions": [
+          "module.tags.enabled",
+          "tags.collection.get",
+          "tags.item.get",
+          "tags.item.put"
+        ],
+        "visible": false
+      },
+      {
+        "permissionName": "ui-tags.delete",
+        "subPermissions": [
+          "module.tags.enabled",
+          "tags.collection.get",
+          "tags.item.get",
+          "tags.item.delete"
+        ],
+        "visible": false
       }
     ]
   },

--- a/translations/ui-tags/en.json
+++ b/translations/ui-tags/en.json
@@ -3,5 +3,11 @@
   "settings.index.paneTitle": "Tags",
   "settings.tags.label": "Tags",
   "settings.general.label": "General",
-  "settings.enableTags": "Enable tags"
+  "settings.enableTags": "Enable tags",
+
+  "permission.all": "Tags: All permissions",
+  "permission.view": "Tags on records: View only",
+  "permission.create": "Tags: Create tags",
+  "permission.edit": "Tags: Edit tags",
+  "permission.delete": "Tags: Delete tags"
 }


### PR DESCRIPTION
Permissions to create tags were not available in any publicly assignable
permission set, leading to errors if any user except `diku_admin`
attempted to create tags.

Refs [UITAG-29](https://issues.folio.org/browse/UITAG-29), [UITAG-10](https://issues.folio.org/browse/UITAG-10)