### PR TITLE
UITAG-32: Update @folio/stripes to v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.1.0 (IN PROGRESS)
 
 * Provide visible permission sets for managing and view tags. Refs UITAG-29, UITAG-10.
+* Update `@folio/stripes` to `v5`. Refs UITAG-32.
 
 ## [3.0.0](https://github.com/folio-org/ui-tags/tree/v3.0.0) (2020-06-10)
 [Full Changelog](https://github.com/folio-org/ui-tags/compare/v2.0.0...v3.0.0)

--- a/package.json
+++ b/package.json
@@ -90,9 +90,9 @@
     "test": "echo 'placeholder. no tests implemented'"
   },
   "devDependencies": {
-    "@folio/eslint-config-stripes": "^5.0.0",
-    "@folio/stripes": "^4.0.0",
-    "@folio/stripes-cli": "^1.4.0",
+    "@folio/eslint-config-stripes": "^5.2.0",
+    "@folio/stripes": "^5.0.0",
+    "@folio/stripes-cli": "^1.18.0",
     "babel-eslint": "^9.0.0",
     "eslint": "^6.2.1",
     "react": "^16.5.0",
@@ -106,7 +106,7 @@
     "redux-form": "^7.0.3"
   },
   "peerDependencies": {
-    "@folio/stripes": "^4.0.0",
+    "@folio/stripes": "^5.0.0",
     "react": "*",
     "react-intl": "^4.5.3"
   }

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "eslint": "^6.2.1",
     "react": "^16.5.0",
     "react-dom": "^16.5.0",
-    "react-intl": "^4.5.3",
+    "react-intl": "^5.8.0",
     "react-redux": "^5.0.7",
     "redux": "^4.0.0"
   },
@@ -108,6 +108,6 @@
   "peerDependencies": {
     "@folio/stripes": "^5.0.0",
     "react": "*",
-    "react-intl": "^4.5.3"
+    "react-intl": "^5.8.0"
   }
 }


### PR DESCRIPTION
Update `@folio/stripes` to `v5`. 
https://issues.folio.org/browse/UITAG-32