### PR TITLE
UITAG-51 Add displayName to "Tags: All permissions" permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-tags
 
+## [6.1.0](IN PROGRESS)
+
+* Add displayName to ui-tags.all permission. Refs UITAG-51.
+
 ## [6.0.0](https://github.com/folio-org/ui-tags/tree/v6.0.0) (2021-10-05)
 [Full Changelog](https://github.com/folio-org/ui-tags/compare/v5.0.1...v6.0.0)
 

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
       },
       {
         "permissionName": "ui-tags.all",
+        "displayName": "Tags: All permissions",
         "subPermissions": [
           "module.tags.enabled",
           "ui-tags.view",


### PR DESCRIPTION
## Description
Add `displayName` to `ui-tags.all` permission to make it searchable by that property

## Issues
[UITAG-51](https://issues.folio.org/browse/UITAG-51)