### PR TITLE
UITAG-38: Settings > Tags : Move focus to second pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-tags
 
+## **6.0.1** (in progress)
+
+* Settings > Tags : Move focus to second pane. Refs UITAG-38.
+
 ## [6.0.0](https://github.com/folio-org/ui-tags/tree/v6.0.0) (2021-10-05)
 [Full Changelog](https://github.com/folio-org/ui-tags/compare/v5.0.1...v6.0.0)
 

--- a/settings/index.js
+++ b/settings/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { createRef } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { Settings } from '@folio/stripes/smart-components';
 
@@ -17,10 +17,19 @@ export default class Tags extends React.Component {
     ];
   }
 
+  paneTitleRef = createRef();
+
+  componentDidMount() {
+    if (this.paneTitleRef.current) {
+      this.paneTitleRef.current.focus();
+    }
+  }
+
   render() {
     return (
       <Settings
         {...this.props}
+        paneTitleRef={this.paneTitleRef}
         pages={this.pages}
         paneTitle={<FormattedMessage id="ui-tags.settings.index.paneTitle" />}
       />


### PR DESCRIPTION
### Description
Move focus to the Tags pane header when selecting Tags under the list of Settings

### Refs
https://issues.folio.org/browse/UITAG-38