### PR TITLE
UITAG-54: Replace babel-eslint with @babel/eslint-parser

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,4 @@
 {
-  "parser": "babel-eslint",
+  "parser": "@babel/eslint-parser",
   "extends": "@folio/eslint-config-stripes"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-tags
 
+## [6.2.0](IN PROGRESS)
+
+* Replace `babel-eslint` with `@babel/eslint-parser`. Refs UITAG-54.
+
 ## [6.1.0](https://github.com/folio-org/ui-tags/tree/v6.1.0) (2022-03-01)
 [Full Changelog](https://github.com/folio-org/ui-tags/compare/v6.0.0...v6.1.0)
 

--- a/package.json
+++ b/package.json
@@ -109,12 +109,12 @@
     "test": "echo 'placeholder. no tests implemented'"
   },
   "devDependencies": {
-    "@folio/eslint-config-stripes": "^5.2.0",
+    "@babel/eslint-parser": "^7.17.0",
+    "@folio/eslint-config-stripes": "^6.1.0",
     "@folio/stripes": "^7.0.0",
-    "@folio/stripes-cli": "^2.0.0",
+    "@folio/stripes-cli": "^2.4.0",
     "@formatjs/cli": "^4.2.6",
-    "babel-eslint": "^9.0.0",
-    "eslint": "^6.2.1",
+    "eslint": "^7.32.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-intl": "^5.8.0",

--- a/settings/index.js
+++ b/settings/index.js
@@ -17,6 +17,7 @@ export default class Tags extends React.Component {
     ];
   }
 
+  // eslint-disable-next-line react/sort-comp
   paneTitleRef = createRef();
 
   componentDidMount() {


### PR DESCRIPTION
## Purpose
Replace `babel-eslint` with `@babel/eslint-parser`.

Issue: [UITAG-54](https://issues.folio.org/browse/UITAG-54)