### PR TITLE
UITAG-61 bump stripes to 8.0.0 for Orchid/2023-R1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Change history for ui-tags
 
-## [6.4.0] (IN PROGRESS)
+## [7.0.0] (IN PROGRESS)
 
 * Refactored <TagsSettings> to be a functional component and added tests. Refs UITAG-58.
+* bump stripes to 8.0.0 for Orchid/2023-R1. Refs UITAG-61.
 
 ## [6.3.0](https://github.com/folio-org/ui-tags/tree/v6.3.0) (2022-10-25)
 [Full Changelog](https://github.com/folio-org/ui-tags/compare/v6.2.0...v6.3.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/tags",
-  "version": "6.3.0",
+  "version": "7.0.0",
   "description": "Tags manager",
   "repository": "folio-org/ui-tags",
   "publishConfig": {
@@ -112,12 +112,12 @@
     "@babel/eslint-parser": "^7.17.0",
     "@babel/plugin-transform-runtime": "^7.19.6",
     "@folio/eslint-config-stripes": "^6.1.0",
-    "@folio/stripes": "^7.0.0",
+    "@folio/stripes": "^8.0.0",
     "@folio/stripes-cli": "^2.6.0",
-    "@folio/stripes-components": "^10.3.0",
-    "@folio/stripes-core": "^8.3.0",
-    "@folio/stripes-form": "^7.1.0",
-    "@folio/stripes-smart-components": "^7.3.0",
+    "@folio/stripes-components": "^11.0.0",
+    "@folio/stripes-core": "^9.0.0",
+    "@folio/stripes-form": "^8.0.0",
+    "@folio/stripes-smart-components": "^8.0.0",
     "@formatjs/cli": "^4.2.6",
     "@testing-library/dom": "^8.19.0",
     "@testing-library/jest-dom": "^5.12.0",
@@ -143,7 +143,7 @@
     "redux-form": "^8.3.7"
   },
   "peerDependencies": {
-    "@folio/stripes": "^7.0.0",
+    "@folio/stripes": "^8.0.0",
     "react": "^17.0.2",
     "react-intl": "^5.8.0"
   }


### PR DESCRIPTION
## Description
bump stripes to 8.0.0 for Orchid/2023-R1

## Issues
[UITAG-61](https://issues.folio.org/browse/UITAG-61)