### PR TITLE
UITAG-63 - Fix issues with View and edit tag settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Refactored <TagsSettings> to be a functional component and added tests. Refs UITAG-58.
 * bump stripes to 8.0.0 for Orchid/2023-R1. Refs UITAG-61.
 * Upgrade `react-redux` to `v8`. Refs UITAG-62.
+* Need new permission(s) to view all Tags settings in UI. Refs UITAG-63.
+* Cannot view or edit tag settings when user is assigned permission "Settings (Tags): Can enable or disable tags for all apps". Refs UITAG-67.
 
 ## [6.3.0](https://github.com/folio-org/ui-tags/tree/v6.3.0) (2022-10-25)
 [Full Changelog](https://github.com/folio-org/ui-tags/compare/v6.2.0...v6.3.0)

--- a/package.json
+++ b/package.json
@@ -43,10 +43,20 @@
         "visible": false
       },
       {
-        "permissionName": "ui-tags.settings",
+        "permissionName": "ui-tags.settings.view",
+        "displayName": "Settings (Tags): Can view tags settings",
+        "subPermissions": [
+          "settings.tags.enabled",
+          "configuration.entries.collection.get"
+        ],
+        "visible": true
+      },
+      {
+        "permissionName": "ui-tags.settings.all",
         "displayName": "Settings (Tags): Can enable or disable tags for all apps",
         "subPermissions": [
-          "settings.tags.enabled"
+          "ui-tags.settings.view",
+          "configuration.entries.collection.put"
         ],
         "visible": true
       },

--- a/settings/TagSettings.js
+++ b/settings/TagSettings.js
@@ -40,6 +40,7 @@ const TagSettings = ({ label }) => {
             id="tags_enabled"
             name="tags_enabled"
             label={intl.formatMessage({ id: 'ui-tags.settings.enableTags' })}
+            disabled={!stripes?.user?.perms['ui-tags.settings.all']}
           />
         </Col>
       </Row>


### PR DESCRIPTION
## Purpose
Need new permission(s) to view all Tags settings in UI. Refs UITAG-63.
Cannot view or edit tag settings when user is assigned permission "Settings (Tags): Can enable or disable tags for all apps". Refs UITAG-67.

## Refs
https://issues.folio.org/browse/UITAG-63
https://issues.folio.org/browse/UITAG-67