### PR TITLE
UITAG-83 - Add display name to permission with name "ui-tags.view"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-tags
 
+## [8.3.0] In progress
+
+* Add display name to permission with name "ui-tags.view". Refs UITAG-83
+
 ## [8.2.0](https://github.com/folio-org/ui-tags/tree/v8.2.0) (2024-10-29)
 [Full Changelog](https://github.com/folio-org/ui-tags/compare/v8.1.0...v8.2.0)
 

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
       },
       {
         "permissionName": "ui-tags.view",
+        "displayName": "Tags on records: View only",
         "subPermissions": [
           "module.tags.enabled",
           "tags.collection.get"


### PR DESCRIPTION
## Purpose
[UITAG-83](https://folio-org.atlassian.net/browse/UITAG-83) - "Tags on records: View only" permission has no display name.

## Approach
A permission `ui-tags.view` with visibility as true has been introduced 4 years ago. But, for some unknown reason, `displayName `was not assigned to the same from `package.json`, although it has been defined on all translations files, fe. https://github.com/folio-org/ui-tags/blob/40ca931702ec98618c6862d91c960564d2f1c910/translations/ui-tags/en.json#L9

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
